### PR TITLE
Add --output-json and --output-dir CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ for doc in result.docs:
 | `hits` | `int` | `10` | Results per page |
 | `sort` | `SortOrder` | `RELEVANCE` | Sort order |
 | `content_type` | `ContentType` | `None` | Filter by content type |
-| `category` | `str` | `None` | Editorial category (articles only) |
+| `category` | `str \| list[str]` | `None` | Editorial category filter (articles only). Pass a list for OR union, e.g. `["politica", "economia"]` |
 | `date_range` | `DateRange` | `None` | Publication date filter |
 | `fetch_content` | `bool` | `False` | Scrape and return full article text for each article result (see [`Document.content`](#document)) |
 
@@ -92,7 +92,7 @@ for doc in result.docs:
 | Attribute | Type | Description |
 |-----------|------|-------------|
 | `id` | `int` | Unique content identifier |
-| `type` | `str` | `"post"`, `"episodes"`, or `"newsletter"` |
+| `type` | `str` | `"post"`, `"flashes"`, `"blog_post"`, `"episodes"`, or `"newsletter"` |
 | `title` | `str` | Content title |
 | `link` | `str` | URL to the content page |
 | `timestamp` | `str` | Publication date (ISO 8601, Italian local time) |
@@ -160,13 +160,16 @@ The `ilpost-search` command is included with the package:
 ```
 usage: ilpost-search [-h] [--type {articles,podcasts,newsletters}]
                      [--sort {relevance,newest,oldest}]
-                     [--date {all,year,month}] [--category CATEGORY]
+                     [--date {all,year,month}] [--category CATEGORY [CATEGORY ...]]
                      [--page PAGE] [--hits HITS] [--all-pages]
                      [--max-pages N] [--fetch-content]
+                     [--output-json] [--output-dir DIR]
                      query
 ```
 
 Each result is printed with labelled fields: `type`, `category`, `title`, `link`, `date`, `score`, `summary`, and either `content` (when `--fetch-content` is used) or `excerpt` (search highlight).
+
+`--output-json` suppresses stdout and writes results to a JSON file instead. The filename is generated automatically from the timestamp and query (e.g. `20260411_143000_matteo_zuppi.json`). Use `--output-dir` to specify a target directory (defaults to the current working directory). The file path is printed to stdout so it can be captured by scripts.
 
 ```bash
 # Basic search
@@ -186,6 +189,15 @@ ilpost-search economia --type newsletters --all-pages --max-pages 3
 
 # Fetch full article text for each result
 ilpost-search bondi --type articles --hits 3 --fetch-content
+
+# Filter by multiple categories (OR union)
+ilpost-search cultivar --category scienza italia mondo
+
+# Save results to a JSON file in the current directory
+ilpost-search berlusconi --hits 20 --output-json
+
+# Save results to a specific directory
+ilpost-search berlusconi --all-pages --output-json --output-dir ~/Desktop
 ```
 
 ## Notes
@@ -194,3 +206,4 @@ ilpost-search bondi --type articles --hits 3 --fetch-content
 - When sorting by date (`NEWEST` or `OLDEST`), `score` is always `0.0`.
 - The `category` filter only applies to articles. It is ignored by the server when `content_type=PODCASTS`.
 - Timestamps are in Italian local time (CET/CEST) with no UTC offset.
+- The search index has a ~5 day lag. Articles published in the last few days will not appear in search results.

--- a/ilpost/cli.py
+++ b/ilpost/cli.py
@@ -1,5 +1,12 @@
+from __future__ import annotations
+
 import argparse
+import json
+import os
+import re
 import sys
+from dataclasses import asdict
+from datetime import datetime
 
 from .client import IlPostClient
 from .models import SortOrder, ContentType, DateRange
@@ -69,6 +76,17 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Scrape and display the full article text (articles only)",
     )
+    parser.add_argument(
+        "--output-json",
+        action="store_true",
+        help="Save results to a JSON file instead of printing to stdout",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        metavar="DIR",
+        help="Directory for the JSON output file (default: current working directory)",
+    )
 
     return parser
 
@@ -96,6 +114,19 @@ _TYPE_LABEL = {
     "episodes": "podcast",
     "newsletter": "newsletter",
 }
+
+
+def _make_output_path(query: str, output_dir: str | None) -> str:
+    slug = re.sub(r"[^\w]+", "_", query).strip("_")[:50]
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    directory = output_dir or os.getcwd()
+    return os.path.join(directory, f"{ts}_{slug}.json")
+
+
+def _result_to_dict(result) -> dict:
+    d = asdict(result)
+    d["total_pages"] = result.total_pages
+    return d
 
 
 def print_result(result, *, show_header: bool = True) -> None:
@@ -143,8 +174,7 @@ def main() -> None:
 
     try:
         if args.all_pages:
-            first = True
-            for page_result in client.paginate(
+            pages = list(client.paginate(
                 args.query,
                 hits=args.hits,
                 sort=sort,
@@ -153,9 +183,22 @@ def main() -> None:
                 date_range=date_range,
                 max_pages=args.max_pages,
                 fetch_content=args.fetch_content,
-            ):
-                print_result(page_result, show_header=first)
-                first = False
+            ))
+            if args.output_json:
+                if pages:
+                    obj = _result_to_dict(pages[0])
+                    obj["docs"] = [d for p in pages for d in asdict(p)["docs"]]
+                else:
+                    obj = {}
+                path = _make_output_path(args.query, args.output_dir)
+                with open(path, "w", encoding="utf-8") as f:
+                    json.dump(obj, f, ensure_ascii=False, indent=2)
+                print(path)
+            else:
+                first = True
+                for page_result in pages:
+                    print_result(page_result, show_header=first)
+                    first = False
         else:
             result = client.search(
                 args.query,
@@ -167,7 +210,13 @@ def main() -> None:
                 date_range=date_range,
                 fetch_content=args.fetch_content,
             )
-            print_result(result)
+            if args.output_json:
+                path = _make_output_path(args.query, args.output_dir)
+                with open(path, "w", encoding="utf-8") as f:
+                    json.dump(_result_to_dict(result), f, ensure_ascii=False, indent=2)
+                print(path)
+            else:
+                print_result(result)
 
     except Exception as exc:
         print(f"Error: {exc}", file=sys.stderr)


### PR DESCRIPTION
## Summary

- Adds `--output-json` flag: saves search results to a JSON file instead of printing to stdout
- Adds `--output-dir DIR` flag: specifies the output directory (default: current working directory)
- Filename is auto-generated from timestamp and query, e.g. `20260411_143000_matteo_zuppi.json`
- Works with both single-page and `--all-pages` modes; multi-page results are merged into one file
- JSON schema follows the wrapper's dataclass structure (`SearchResult` + `Document`)
- The output file path is printed to stdout for script capture

## Documentation

- `README.md` updated with new CLI flags, examples, multi-category `--category` usage, `Document.type` values for `flashes`/`blog_post`, and the ~5 day search index lag note

## Test plan

- [ ] `ilpost-search berlusconi --hits 3 --output-json` → file created, path printed to stdout
- [ ] `--output-dir ~/Desktop` → file written to specified directory
- [ ] `--all-pages --max-pages 2 --output-json` → docs from all pages merged into one file
- [ ] `--fetch-content --output-json` → `content` field populated in JSON for article results
- [ ] Without `--output-json` → behaviour unchanged (stdout output as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
