### PR TITLE
Add get_by_date() method and --archive-date CLI flag (v0.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.5.0] - 2026-04-11
+
+### Added
+- **`get_by_date(date, *, fetch_content=False)`:** new method on `IlPostClient` that
+  returns all articles published on a given date by scraping the Il Post date-archive
+  page (`https://www.ilpost.it/YYYY/MM/DD/`). All pages are fetched automatically
+  (20 articles per page). Each article is enriched with API fields (id, tags, category,
+  subscriber status, full timestamp) via a title-based search lookup. Articles that
+  cannot be matched in the search index are excluded from the results. Closes #2.
+- **`--archive-date YYYY-MM-DD` CLI flag:** fetches all articles published on a specific
+  date. Supports `--fetch-content` and `--output-json` / `--output-dir`. Passing a date
+  within the last 5 days raises an error (search index lag).
+- Progress logging to stderr during `get_by_date()` (archive page fetching, per-article
+  enrichment progress, final count).
+- Tags (`post_tag_text`) are now displayed in CLI output.
+
+### Changed
+- `query` is now optional in the CLI — either a query or `--archive-date` must be provided.
+- **`--output-json` / `--output-dir` flags** (previously unreleased, deferred from 0.4.x):
+  suppresses stdout and writes results to a timestamped JSON file. The output path is
+  printed to stdout for scripting. Closes #5.
+
+---
+
 ## [0.4.2] - 2026-04-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ for doc in result.docs:
 | `search_podcasts(query, ...)` | Podcast episodes only |
 | `search_newsletters(query, ...)` | Newsletter issues only |
 | `paginate(query, ...)` | Generator that yields one `SearchResult` per page |
+| `get_by_date(date, ...)` | All articles published on a specific date (scrapes the date-archive page) |
 
 #### Common parameters
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,18 @@ for doc in result.docs:
 | `date_range` | `DateRange` | `None` | Publication date filter |
 | `fetch_content` | `bool` | `False` | Scrape and return full article text for each article result (see [`Document.content`](#document)) |
 
-> `fetch_content` is available on `search()`, `search_articles()`, and `paginate()`. It has no effect on podcast or newsletter results — `doc.content` will be `None` for those types.
+> `fetch_content` is available on `search()`, `search_articles()`, `paginate()`, and `get_by_date()`. It has no effect on podcast or newsletter results — `doc.content` will be `None` for those types.
+
+#### `get_by_date(date, *, fetch_content=False)`
+
+Returns all articles published on *date* by scraping the Il Post date-archive page (`https://www.ilpost.it/YYYY/MM/DD/`), paginating through all pages automatically. Each article is then enriched with API fields (id, tags, category, subscriber status, full timestamp) via a title-based search lookup. Articles that cannot be matched in the search index are excluded from the results.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `date` | `datetime.date` | — | Publication date to fetch |
+| `fetch_content` | `bool` | `False` | Scrape the full article body for each result |
+
+Raises `ValueError` if *date* is in the future or within the last 5 days (the search index has a ~5 day lag; recent dates cannot be enriched).
 
 #### Enums
 
@@ -152,6 +163,12 @@ for doc in result.docs:
 # Use the scraper directly (e.g. for parallel fetching)
 from ilpost import fetch_article_content
 text = fetch_article_content("https://www.ilpost.it/2026/04/02/...")
+
+# Fetch all articles published on a specific date
+import datetime
+docs = client.get_by_date(datetime.date(2025, 11, 12))
+for doc in docs:
+    print(doc.title, doc.timestamp)
 ```
 
 ## CLI
@@ -162,13 +179,13 @@ The `ilpost-search` command is included with the package:
 usage: ilpost-search [-h] [--type {articles,podcasts,newsletters}]
                      [--sort {relevance,newest,oldest}]
                      [--date {all,year,month}] [--category CATEGORY [CATEGORY ...]]
-                     [--page PAGE] [--hits HITS] [--all-pages]
-                     [--max-pages N] [--fetch-content]
-                     [--output-json] [--output-dir DIR]
-                     query
+                     [--page PAGE] [--hits HITS] [--all-pages] [--max-pages N]
+                     [--fetch-content] [--output-json] [--output-dir DIR]
+                     [--archive-date YYYY-MM-DD]
+                     [query]
 ```
 
-Each result is printed with labelled fields: `type`, `category`, `title`, `link`, `date`, `score`, `summary`, and either `content` (when `--fetch-content` is used) or `excerpt` (search highlight).
+Each result is printed with labelled fields: `type`, `category`, `tags`, `title`, `link`, `date`, `score`, `summary`, and either `content` (when `--fetch-content` is used) or `excerpt` (search highlight).
 
 `--output-json` suppresses stdout and writes results to a JSON file instead. The filename is generated automatically from the timestamp and query (e.g. `20260411_143000_matteo_zuppi.json`). Use `--output-dir` to specify a target directory (defaults to the current working directory). The file path is printed to stdout so it can be captured by scripts.
 
@@ -199,6 +216,15 @@ ilpost-search berlusconi --hits 20 --output-json
 
 # Save results to a specific directory
 ilpost-search berlusconi --all-pages --output-json --output-dir ~/Desktop
+
+# Fetch all articles published on a specific date
+ilpost-search --archive-date 2025-11-12
+
+# Fetch articles by date and save to JSON
+ilpost-search --archive-date 2025-11-12 --output-json
+
+# Fetch articles by date with full content
+ilpost-search --archive-date 2025-11-12 --fetch-content
 ```
 
 ## Notes

--- a/ilpost/cli.py
+++ b/ilpost/cli.py
@@ -147,6 +147,8 @@ def _print_doc(doc) -> None:
     print(f"  score    : {doc.score:.2f}")
     if doc.is_paywalled:
         print(f"  access   : subscribers only")
+    if doc.post_tag_text:
+        print(f"  tags     : {', '.join(doc.post_tag_text)}")
     if doc.summary:
         print(f"  summary  : {doc.summary}")
     if doc.content:

--- a/ilpost/cli.py
+++ b/ilpost/cli.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import argparse
+import datetime
 import json
 import os
 import re
 import sys
 from dataclasses import asdict
-from datetime import datetime
 
 from .client import IlPostClient
 from .models import SortOrder, ContentType, DateRange
@@ -18,7 +18,7 @@ def build_parser() -> argparse.ArgumentParser:
         description="Search Il Post articles, podcasts, and newsletters.",
     )
 
-    parser.add_argument("query", help="Search term")
+    parser.add_argument("query", nargs="?", default=None, help="Search term")
 
     parser.add_argument(
         "--type", "-t",
@@ -87,6 +87,13 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="DIR",
         help="Directory for the JSON output file (default: current working directory)",
     )
+    parser.add_argument(
+        "--archive-date",
+        default=None,
+        metavar="YYYY-MM-DD",
+        help="Fetch all articles published on a specific date. "
+             "Date must be at least 5 days in the past.",
+    )
 
     return parser
 
@@ -118,7 +125,7 @@ _TYPE_LABEL = {
 
 def _make_output_path(query: str, output_dir: str | None) -> str:
     slug = re.sub(r"[^\w]+", "_", query).strip("_")[:50]
-    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     directory = output_dir or os.getcwd()
     return os.path.join(directory, f"{ts}_{slug}.json")
 
@@ -127,6 +134,27 @@ def _result_to_dict(result) -> dict:
     d = asdict(result)
     d["total_pages"] = result.total_pages
     return d
+
+
+def _print_doc(doc) -> None:
+    label = _TYPE_LABEL.get(doc.type, doc.type)
+    print(f"  type     : {label}")
+    if doc.category:
+        print(f"  category : {doc.category}")
+    print(f"  title    : {doc.title}")
+    print(f"  link     : {doc.link}")
+    print(f"  date     : {doc.timestamp}")
+    print(f"  score    : {doc.score:.2f}")
+    if doc.is_paywalled:
+        print(f"  access   : subscribers only")
+    if doc.summary:
+        print(f"  summary  : {doc.summary}")
+    if doc.content:
+        print(f"  content  : {doc.content}")
+    elif doc.highlight:
+        snippet = doc.highlight.replace("<span>", ">>").replace("</span>", "<<")
+        print(f"  excerpt  : ...{snippet}...")
+    print()
 
 
 def print_result(result, *, show_header: bool = True) -> None:
@@ -142,35 +170,48 @@ def print_result(result, *, show_header: bool = True) -> None:
         return
 
     for doc in result.docs:
-        label = _TYPE_LABEL.get(doc.type, doc.type)
-        print(f"  type     : {label}")
-        if doc.category:
-            print(f"  category : {doc.category}")
-        print(f"  title    : {doc.title}")
-        print(f"  link     : {doc.link}")
-        print(f"  date     : {doc.timestamp}")
-        print(f"  score    : {doc.score:.2f}")
-        if doc.is_paywalled:
-            print(f"  access   : subscribers only")
-        if doc.summary:
-            print(f"  summary  : {doc.summary}")
-        if doc.content:
-            print(f"  content  : {doc.content}")
-        elif doc.highlight:
-            snippet = doc.highlight.replace("<span>", ">>").replace("</span>", "<<")
-            print(f"  excerpt  : ...{snippet}...")
-        print()
+        _print_doc(doc)
+
+
+def print_docs(docs: list, *, date_str: str = "") -> None:
+    print(f"\nDate: {date_str}  |  Total: {len(docs)}")
+    print("-" * 72)
+    if not docs:
+        print("No results.")
+        return
+    for doc in docs:
+        _print_doc(doc)
 
 
 def main() -> None:
     parser = build_parser()
     args = parser.parse_args()
 
+    if args.archive_date is None and args.query is None:
+        parser.error("provide a search query or --archive-date")
+
     sort = _SORT_MAP[args.sort]
     content_type = _CTYPE_MAP.get(args.content_type)
     date_range = _DATE_MAP.get(args.date_range)
 
     client = IlPostClient()
+
+    try:
+        if args.archive_date:
+            date = datetime.date.fromisoformat(args.archive_date)
+            docs = client.get_by_date(date, fetch_content=args.fetch_content)
+            if args.output_json:
+                obj = {"date": args.archive_date, "total": len(docs), "docs": [asdict(d) for d in docs]}
+                path = _make_output_path(args.archive_date, args.output_dir)
+                with open(path, "w", encoding="utf-8") as f:
+                    json.dump(obj, f, ensure_ascii=False, indent=2)
+                print(path)
+            else:
+                print_docs(docs, date_str=args.archive_date)
+            return
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
 
     try:
         if args.all_pages:

--- a/ilpost/client.py
+++ b/ilpost/client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 import json
+import sys
 import urllib.request
 from typing import Optional, Union
 from urllib.parse import urlencode, quote
@@ -319,13 +320,18 @@ class IlPostClient:
         page = 1
         while True:
             url = f"{base}/" if page == 1 else f"{base}/page/{page}/"
+            print(f"Fetching archive page {page}...", file=sys.stderr)
             items = fetch_archive_page(url, self.timeout)
             if not items:
                 break
             docs.extend(_doc_from_archive_item(i) for i in items)
             page += 1
 
-        for doc in docs:
+        print(f"Found {len(docs)} articles. Enriching from API...", file=sys.stderr)
+        for i, doc in enumerate(docs, 1):
+            print(f"  [{i}/{len(docs)}] {doc.title[:70]}", file=sys.stderr)
             _enrich_doc_from_search(doc, self)
+        if fetch_content:
+            print("Fetching article content...", file=sys.stderr)
         self._enrich_docs(docs, fetch_content)
         return docs

--- a/ilpost/client.py
+++ b/ilpost/client.py
@@ -49,6 +49,7 @@ def _enrich_doc_from_search(doc: Document, client: IlPostClient) -> None:
             if found.link.rstrip("/") == doc.link.rstrip("/"):
                 doc.id = found.id
                 doc.subscriber = found.subscriber
+                doc.timestamp = found.timestamp
                 doc.post_tag_text = found.post_tag_text
                 if found.category:
                     doc.category = found.category

--- a/ilpost/client.py
+++ b/ilpost/client.py
@@ -14,14 +14,14 @@ _BASE_URL = "https://api.ilpost.org/search/api/site_search/"
 _ARCHIVE_BASE_URL = "https://www.ilpost.it"
 
 
-def _doc_from_archive_item(item: dict) -> Document:
+def _doc_from_archive_item(item: dict, date: datetime.date) -> Document:
     link = item.get("link", "")
     doc_type = "flashes" if "/flashes/" in link else "post"
     raw_ts = item.get("timestamp", "")
     try:
         ts = datetime.datetime.strptime(raw_ts, "%d/%m/%Y").strftime("%Y-%m-%dT00:00:00")
     except ValueError:
-        ts = raw_ts
+        ts = date.strftime("%Y-%m-%dT00:00:00")
     return Document(
         id=0,
         type=doc_type,
@@ -324,13 +324,15 @@ class IlPostClient:
             items = fetch_archive_page(url, self.timeout)
             if not items:
                 break
-            docs.extend(_doc_from_archive_item(i) for i in items)
+            docs.extend(_doc_from_archive_item(i, date) for i in items)
             page += 1
 
         print(f"Found {len(docs)} articles. Enriching from API...", file=sys.stderr)
         for i, doc in enumerate(docs, 1):
             print(f"  [{i}/{len(docs)}] {doc.title[:70]}", file=sys.stderr)
             _enrich_doc_from_search(doc, self)
+        docs = [doc for doc in docs if doc.id != 0]
+        print(f"Enriched {len(docs)} articles.", file=sys.stderr)
         if fetch_content:
             print("Fetching article content...", file=sys.stderr)
         self._enrich_docs(docs, fetch_content)

--- a/ilpost/client.py
+++ b/ilpost/client.py
@@ -1,15 +1,59 @@
 from __future__ import annotations
 
+import datetime
+import json
+import urllib.request
 from typing import Optional, Union
 from urllib.parse import urlencode, quote
 
-import urllib.request
-import json
-
-from .models import SearchResult, SortOrder, ContentType, DateRange
-from .scraper import fetch_article_content
+from .models import Document, SearchResult, SortOrder, ContentType, DateRange
+from .scraper import fetch_article_content, fetch_archive_page
 
 _BASE_URL = "https://api.ilpost.org/search/api/site_search/"
+_ARCHIVE_BASE_URL = "https://www.ilpost.it"
+
+
+def _doc_from_archive_item(item: dict) -> Document:
+    link = item.get("link", "")
+    doc_type = "flashes" if "/flashes/" in link else "post"
+    raw_ts = item.get("timestamp", "")
+    try:
+        ts = datetime.datetime.strptime(raw_ts, "%d/%m/%Y").strftime("%Y-%m-%dT00:00:00")
+    except ValueError:
+        ts = raw_ts
+    return Document(
+        id=0,
+        type=doc_type,
+        title=item.get("title", "").strip(),
+        link=link,
+        timestamp=ts,
+        summary=item.get("summary", "").strip(),
+        image=item.get("image", ""),
+        score=0.0,
+        subscriber=False,
+    )
+
+
+def _enrich_doc_from_search(doc: Document, client: IlPostClient) -> None:
+    """Try to fill missing API fields (id, tags, subscriber, etc.) via title search."""
+    words = doc.title.split()
+    queries = [f'"{doc.title}"']
+    if len(words) > 6:
+        queries.append(f'"{" ".join(words[:6])}"')
+    for query in queries:
+        try:
+            result = client.search(query, hits=5, sort=SortOrder.NEWEST)
+        except Exception:
+            return
+        for found in result.docs:
+            if found.link.rstrip("/") == doc.link.rstrip("/"):
+                doc.id = found.id
+                doc.subscriber = found.subscriber
+                doc.post_tag_text = found.post_tag_text
+                if found.category:
+                    doc.category = found.category
+                doc.derived_info = found.derived_info
+                return
 
 
 def _build_filters(
@@ -231,3 +275,56 @@ class IlPostClient:
             if max_pages is not None and page >= max_pages:
                 break
             page += 1
+
+    def get_by_date(
+        self,
+        date: datetime.date,
+        *,
+        fetch_content: bool = False,
+    ) -> list[Document]:
+        """Return all articles published on *date* by scraping the date-archive page.
+
+        Each article is enriched with API fields (id, tags, subscriber status, etc.)
+        via a title-based search lookup. If a match cannot be confirmed by URL comparison,
+        the article is returned with partial data only.
+
+        Parameters
+        ----------
+        date:
+            The publication date to fetch. Must be at least 5 days in the past
+            (the search index has a ~5 day lag; recent dates are rejected).
+        fetch_content:
+            If ``True``, scrape the full article body for each result.
+
+        Returns
+        -------
+        list[Document]
+
+        Raises
+        ------
+        ValueError
+            If *date* is in the future or within the last 5 days.
+        """
+        today = datetime.date.today()
+        if date > today:
+            raise ValueError(f"date cannot be in the future: {date}")
+        if (today - date).days < 5:
+            raise ValueError(
+                f"{date} is too recent — archive dates must be at least 5 days in the past"
+            )
+
+        base = f"{_ARCHIVE_BASE_URL}/{date.year:04d}/{date.month:02d}/{date.day:02d}"
+        docs: list[Document] = []
+        page = 1
+        while True:
+            url = f"{base}/" if page == 1 else f"{base}/page/{page}/"
+            items = fetch_archive_page(url, self.timeout)
+            if not items:
+                break
+            docs.extend(_doc_from_archive_item(i) for i in items)
+            page += 1
+
+        for doc in docs:
+            _enrich_doc_from_search(doc, self)
+        self._enrich_docs(docs, fetch_content)
+        return docs

--- a/ilpost/scraper.py
+++ b/ilpost/scraper.py
@@ -92,3 +92,113 @@ def fetch_article_content(url: str, timeout: int = 10) -> Optional[str]:
         return parser.text
     except Exception:
         return None
+
+
+class ArchivePageScraper(HTMLParser):
+    """Extract article listings from an Il Post date-archive page.
+
+    Parses ``<article>`` elements inside ``<main id="main-content">`` and
+    collects link, title, summary, timestamp, and image for each item.
+
+    After calling ``feed(html)``, read results from ``.items``
+    (list of dicts, one per article).
+    """
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._in_main: bool = False
+        self._in_article: bool = False
+        self._link_captured: bool = False
+        self._in_time: bool = False
+        self._in_h2: bool = False
+        self._in_p: bool = False
+        self._current: dict = {}
+        self.items: list[dict] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attrs_dict = dict(attrs)
+
+        if tag == "main" and attrs_dict.get("id") == "main-content":
+            self._in_main = True
+            return
+
+        if not self._in_main:
+            return
+
+        if tag == "article":
+            self._in_article = True
+            self._link_captured = False
+            self._current = {"link": "", "timestamp": "", "title": "", "summary": "", "image": ""}
+            return
+
+        if not self._in_article:
+            return
+
+        if tag == "a" and not self._link_captured:
+            href = attrs_dict.get("href", "")
+            if href:
+                self._current["link"] = href
+                self._link_captured = True
+        elif tag == "time":
+            self._in_time = True
+        elif tag == "h2":
+            self._in_h2 = True
+        elif tag == "p" and not self._in_p:
+            self._in_p = True
+        elif tag == "img" and not self._current["image"]:
+            self._current["image"] = attrs_dict.get("src", "")
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "main":
+            self._in_main = False
+            return
+
+        if not self._in_main:
+            return
+
+        if tag == "article":
+            if self._in_article and self._current.get("link"):
+                self.items.append(self._current)
+            self._in_article = False
+            self._current = {}
+            return
+
+        if not self._in_article:
+            return
+
+        if tag == "time":
+            self._in_time = False
+        elif tag == "h2":
+            self._in_h2 = False
+        elif tag == "p":
+            self._in_p = False
+
+    def handle_data(self, data: str) -> None:
+        if not self._in_article:
+            return
+        text = data.strip()
+        if not text:
+            return
+        if self._in_time:
+            self._current["timestamp"] = text
+        elif self._in_h2:
+            self._current["title"] += text
+        elif self._in_p:
+            self._current["summary"] += text
+
+
+def fetch_archive_page(url: str, timeout: int = 10) -> list[dict]:
+    """Fetch one page of a date-archive URL and return raw article dicts.
+
+    Returns an empty list on any error (network, parsing, or empty page).
+    """
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            charset = response.headers.get_content_charset() or "utf-8"
+            html = response.read().decode(charset, errors="replace")
+        parser = ArchivePageScraper()
+        parser.feed(html)
+        return parser.items
+    except Exception:
+        return []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ilpost-api-wrapper"
-version = "0.4.2"
+version = "0.5.0"
 description = "Python wrapper for Il Post newspaper API"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

- Adds `IlPostClient.get_by_date(date, *, fetch_content=False)` — scrapes the Il Post date-archive page across all pages, then enriches each article via title-based API lookup (id, tags, category, subscriber status, full timestamp). Articles that cannot be matched are excluded from results. Closes #2.
- Adds `--archive-date YYYY-MM-DD` CLI flag with support for `--fetch-content`, `--output-json`, and `--output-dir`. Dates within the last 5 days raise a `ValueError`.
- Adds `--output-json` / `--output-dir` flags (deferred from PR #8). Closes #5.
- Tags (`post_tag_text`) now shown in CLI output.
- Progress logging to stderr during archive fetch and enrichment.
- Bumps version to 0.5.0.

## Test plan

- [ ] `ilpost-search --archive-date 2026-04-10` → error (too recent)
- [ ] `ilpost-search --archive-date 2027-01-01` → error (future date)
- [ ] `ilpost-search --archive-date 2025-11-12` → prints articles with tags and full timestamps
- [ ] `ilpost-search --archive-date 2025-11-12 --output-json` → writes JSON file, prints path
- [ ] `ilpost-search berlusconi --hits 3` → existing search unaffected, tags visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)
