### PR TITLE
Fix get_by_date() enrichment for pre-2017 archives (v0.5.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__/
 .claude/settings.local.json
 dist/
+diagnose_get_by_date.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.5.1] - 2026-04-12
+
+### Fixed
+- **`get_by_date()` enrichment improvements:**
+  - Added summary-keyword fallback search (up to 7 words, relevance-sorted) when
+    title phrase queries fail to match.
+  - Fixed corrupted apostrophes in title queries: archive page titles containing
+    Windows-1252 `\x92` bytes (decoded as `\ufffd`) are now normalised to `'`
+    before searching.
+  - Fixed trailing punctuation in title and summary query tokens (e.g. `imprecisioni,`
+    → `imprecisioni`).
+  - Extracted `_clean_query_words()` helper used by both title and summary paths.
+- **Additional skippable article types** recognised and excluded before enrichment:
+  Peanuts comic strips, daily photo roundups, `le-prime-pagine-*` (newspaper
+  front-page galleries), and meteo forecast articles
+  (`title.startswith("Le previsioni meteo")`).
+
+---
+
 ## [0.5.0] - 2026-04-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ for doc in result.docs:
 
 #### `get_by_date(date, *, fetch_content=False)`
 
-Returns all articles published on *date* by scraping the Il Post date-archive page (`https://www.ilpost.it/YYYY/MM/DD/`), paginating through all pages automatically. Each article is then enriched with API fields (id, tags, category, subscriber status, full timestamp) via a title-based search lookup. Articles that cannot be matched in the search index are excluded from the results.
+Returns all articles published on *date* by scraping the Il Post date-archive page (`https://www.ilpost.it/YYYY/MM/DD/`), paginating through all pages automatically. Each article is then enriched with API fields (id, tags, category, subscriber status, full timestamp) via a title-based search lookup (with a summary-keyword fallback). Articles that cannot be matched in the search index are excluded from the results.
+
+The following recurring article types are automatically skipped before enrichment, as they are not available in the search API: post-it external-link articles (pre-2017), Peanuts comic strips, daily photo roundups, newspaper front-page galleries (`le-prime-pagine-*`), and meteo forecast articles.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|

--- a/ilpost/client.py
+++ b/ilpost/client.py
@@ -105,7 +105,7 @@ def _enrich_doc_from_search(doc: Document, client: IlPostClient) -> None:
         if len(summary_words) >= 3:
             summary_query = " ".join(summary_words[:5])
             try:
-                result = client.search(summary_query, hits=10, sort=SortOrder.NEWEST)
+                result = client.search(summary_query, hits=20, sort=SortOrder.RELEVANCE)
             except Exception:
                 return
             for found in result.docs:

--- a/ilpost/client.py
+++ b/ilpost/client.py
@@ -35,6 +35,8 @@ def _is_skippable(doc: Document) -> bool:
         return True
     if "le-prime-pagine-" in doc.link:
         return True
+    if doc.title.startswith("Le previsioni meteo"):
+        return True
     return False
 
 
@@ -105,7 +107,7 @@ def _enrich_doc_from_search(doc: Document, client: IlPostClient) -> None:
     if doc.summary:
         summary_words = _clean_query_words(doc.summary, min_len=5)
         if len(summary_words) >= 3:
-            summary_query = " ".join(summary_words[:5])
+            summary_query = " ".join(summary_words[:7])
             try:
                 result = client.search(summary_query, hits=20, sort=SortOrder.RELEVANCE)
             except Exception:

--- a/ilpost/client.py
+++ b/ilpost/client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 import json
+import re
 import sys
 import urllib.request
 from typing import Optional, Union
@@ -12,6 +13,27 @@ from .scraper import fetch_article_content, fetch_archive_page
 
 _BASE_URL = "https://api.ilpost.org/search/api/site_search/"
 _ARCHIVE_BASE_URL = "https://www.ilpost.it"
+
+_POSTIT_IMAGE = "https://www.ilpost.it/wp-content/uploads/2019/10/ilpost-anteprima-colore.png"
+
+_ITALIAN_DATE_TITLE_RE = re.compile(
+    r"^(lunedì|martedì|mercoledì|giovedì|venerdì|sabato|domenica)"
+    r"\s+\d{1,2}\s+"
+    r"(gennaio|febbraio|marzo|aprile|maggio|giugno|luglio|agosto"
+    r"|settembre|ottobre|novembre|dicembre)$",
+    re.IGNORECASE,
+)
+
+
+def _is_skippable(doc: Document) -> bool:
+    """Return True for archive articles not available in the search API."""
+    if doc.image == _POSTIT_IMAGE:
+        return True
+    if doc.title.startswith("Peanuts"):
+        return True
+    if _ITALIAN_DATE_TITLE_RE.match(doc.title):
+        return True
+    return False
 
 
 def _doc_from_archive_item(item: dict, date: datetime.date) -> Document:
@@ -35,8 +57,19 @@ def _doc_from_archive_item(item: dict, date: datetime.date) -> Document:
     )
 
 
+def _apply_enrichment(doc: Document, found: Document) -> None:
+    doc.id = found.id
+    doc.subscriber = found.subscriber
+    doc.timestamp = found.timestamp
+    doc.post_tag_text = found.post_tag_text
+    if found.category:
+        doc.category = found.category
+    doc.derived_info = found.derived_info
+
+
 def _enrich_doc_from_search(doc: Document, client: IlPostClient) -> None:
-    """Try to fill missing API fields (id, tags, subscriber, etc.) via title search."""
+    """Try to fill missing API fields (id, tags, subscriber, etc.) via title search,
+    with a summary-based keyword search as fallback."""
     words = doc.title.split()
     queries = [f'"{doc.title}"']
     if len(words) > 6:
@@ -48,14 +81,22 @@ def _enrich_doc_from_search(doc: Document, client: IlPostClient) -> None:
             return
         for found in result.docs:
             if found.link.rstrip("/") == doc.link.rstrip("/"):
-                doc.id = found.id
-                doc.subscriber = found.subscriber
-                doc.timestamp = found.timestamp
-                doc.post_tag_text = found.post_tag_text
-                if found.category:
-                    doc.category = found.category
-                doc.derived_info = found.derived_info
+                _apply_enrichment(doc, found)
                 return
+
+    # Fallback: keyword search on summary words
+    if doc.summary:
+        summary_words = [w for w in doc.summary.split() if len(w) > 4]
+        if len(summary_words) >= 3:
+            summary_query = " ".join(summary_words[:5])
+            try:
+                result = client.search(summary_query, hits=10, sort=SortOrder.NEWEST)
+            except Exception:
+                return
+            for found in result.docs:
+                if found.link.rstrip("/") == doc.link.rstrip("/"):
+                    _apply_enrichment(doc, found)
+                    return
 
 
 def _build_filters(
@@ -327,6 +368,13 @@ class IlPostClient:
             docs.extend(_doc_from_archive_item(i, date) for i in items)
             page += 1
 
+        skippable = [d for d in docs if _is_skippable(d)]
+        docs = [d for d in docs if not _is_skippable(d)]
+        if skippable:
+            print(
+                f"Skipped {len(skippable)} non-API articles (post-it/comics/photos).",
+                file=sys.stderr,
+            )
         print(f"Found {len(docs)} articles. Enriching from API...", file=sys.stderr)
         for i, doc in enumerate(docs, 1):
             print(f"  [{i}/{len(docs)}] {doc.title[:70]}", file=sys.stderr)

--- a/ilpost/client.py
+++ b/ilpost/client.py
@@ -33,6 +33,8 @@ def _is_skippable(doc: Document) -> bool:
         return True
     if _ITALIAN_DATE_TITLE_RE.match(doc.title):
         return True
+    if "le-prime-pagine-" in doc.link:
+        return True
     return False
 
 

--- a/ilpost/client.py
+++ b/ilpost/client.py
@@ -57,6 +57,20 @@ def _doc_from_archive_item(item: dict, date: datetime.date) -> Document:
     )
 
 
+def _clean_query_words(text: str, min_len: int = 1) -> list[str]:
+    """Return clean tokens from *text* suitable for use in a search query.
+
+    Steps:
+    1. Replace Windows-1252 apostrophe replacement char with a real apostrophe.
+    2. Split on whitespace.
+    3. Strip trailing punctuation (.,;:!?) from each token.
+    4. Drop tokens shorter than *min_len*.
+    """
+    text = text.replace("\ufffd", "'")
+    words = [re.sub(r"[.,;:!?]+$", "", w) for w in text.split()]
+    return [w for w in words if len(w) >= min_len]
+
+
 def _apply_enrichment(doc: Document, found: Document) -> None:
     doc.id = found.id
     doc.subscriber = found.subscriber
@@ -70,10 +84,11 @@ def _apply_enrichment(doc: Document, found: Document) -> None:
 def _enrich_doc_from_search(doc: Document, client: IlPostClient) -> None:
     """Try to fill missing API fields (id, tags, subscriber, etc.) via title search,
     with a summary-based keyword search as fallback."""
-    words = doc.title.split()
-    queries = [f'"{doc.title}"']
-    if len(words) > 6:
-        queries.append(f'"{" ".join(words[:6])}"')
+    title_words = _clean_query_words(doc.title)
+    clean_title = " ".join(title_words)
+    queries = [f'"{clean_title}"']
+    if len(title_words) > 6:
+        queries.append(f'"{" ".join(title_words[:6])}"')
     for query in queries:
         try:
             result = client.search(query, hits=5, sort=SortOrder.NEWEST)
@@ -84,9 +99,9 @@ def _enrich_doc_from_search(doc: Document, client: IlPostClient) -> None:
                 _apply_enrichment(doc, found)
                 return
 
-    # Fallback: keyword search on summary words
+    # Fallback: keyword search on summary words (stripped of punctuation)
     if doc.summary:
-        summary_words = [w for w in doc.summary.split() if len(w) > 4]
+        summary_words = _clean_query_words(doc.summary, min_len=5)
         if len(summary_words) >= 3:
             summary_query = " ".join(summary_words[:5])
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ilpost-api-wrapper"
-version = "0.5.0"
+version = "0.5.1"
 description = "Python wrapper for Il Post newspaper API"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

- Fixes systematic enrichment failures in `get_by_date()` for older archive dates
- Adds a summary-keyword fallback search (up to 7 words, relevance-sorted) when title phrase queries fail to match
- Fixes corrupted apostrophes and trailing punctuation in search query tokens
- Extracts `_clean_query_words()` helper shared by both title and summary paths
- Skips recurring article types not available in the search API: Peanuts comics, daily photo roundups, newspaper front-page galleries (`le-prime-pagine-*`), and meteo forecast articles

## Test plan

- [ ] Run `python diagnose_get_by_date.py 2017-03-22` -- expect 0 dropped, skippable articles labelled correctly
- [ ] Run `python diagnose_get_by_date.py 2014-01-05` -- expect `le-prime-pagine-oggi-*` articles skipped
- [ ] Verify "Fatto male" (https://www.ilpost.it/2017/03/22/fatto-male/) is enriched via summary fallback

Generated with Claude Code
